### PR TITLE
Do a more complete object type check to catch case that elem is undefined

### DIFF
--- a/lib/json0.js
+++ b/lib/json0.js
@@ -22,6 +22,17 @@ var isArray = function(obj) {
 };
 
 /**
+ * Checks if the passed object is an Object instance.
+ * No function call (fast) version
+ *
+ * @param obj
+ * @returns {boolean}
+ */
+var isObject = function(obj) {
+  return (!!obj) && (obj.constructor === Object);
+};
+
+/**
  * Clones the passed object using JSON serialization (which is slow).
  *
  * hax, copied from test/types/json. Apparently this is still the fastest way
@@ -100,7 +111,7 @@ json.checkList = function(elem) {
 };
 
 json.checkObj = function(elem) {
-  if (elem.constructor !== Object) {
+  if (!isObject(elem)) {
     throw new Error("Referenced element not an object (it was " + JSON.stringify(elem) + ")");
   }
 };

--- a/test/json0.coffee
+++ b/test/json0.coffee
@@ -379,10 +379,13 @@ genTests = (type) ->
 
   describe 'randomizer', ->
     it 'passes', ->
+      @timeout 6000
       @slow 6000
       fuzzer type, require('./json0-generator'), 1000
 
     it 'passes with string subtype', ->
+      @timeout 4000
+      @slow 4000
       type._testStringSubtype = true # hack
       fuzzer type, require('./json0-generator'), 1000
       delete type._testStringSubtype

--- a/test/text0.coffee
+++ b/test/text0.coffee
@@ -77,16 +77,16 @@ describe 'text0', ->
       testUnchanged []
       testUnchanged [{i:'asdf', p:100}]
       testUnchanged [{i:'asdf', p:100}, {d:'fdsa', p:123}]
-    
+
     it 'adds missing p:0', ->
       assert.deepEqual [{i:'abc', p:0}], text0.normalize [{i:'abc'}]
       assert.deepEqual [{d:'abc', p:0}], text0.normalize [{d:'abc'}]
       assert.deepEqual [{i:'abc', p:0}, {d:'abc', p:0}], text0.normalize [{i:'abc'}, {d:'abc'}]
-    
+
     it 'converts op to an array', ->
       assert.deepEqual [{i:'abc', p:0}], text0.normalize {i:'abc', p:0}
       assert.deepEqual [{d:'abc', p:0}], text0.normalize {d:'abc', p:0}
-    
+
     it 'works with a really simple op', ->
       assert.deepEqual [{i:'abc', p:0}], text0.normalize {i:'abc'}
 
@@ -114,6 +114,7 @@ describe 'text0', ->
 
 
   describe 'randomizer', -> it 'passes', ->
+    @timeout 4000
     @slow 4000
     fuzzer text0, require('./text0-generator')
 


### PR DESCRIPTION
We've been seeing a rare occurence issue where elem during json.checkObj in apply is called on an undefined elem.

Still not sure of the root cause of the issue. But I believe this is a better object check that results in the error being thrown properly.  Otherwise you get a stack trace like: 


    TypeError: Cannot read property 'constructor' of undefined
    at Object.json.checkObj (/var/lever/hire2/node_modules/derby/node_modules/racer/node_modules/share/node_modules/ottypes/lib/json0.js:103:11)
    at Object.json.apply (/var/lever/hire2/node_modules/derby/node_modules/racer/node_modules/share/node_modules/ottypes/lib/json0.js:204:12)
    at Object.json.incrementalApply (/var/lever/hire2/node_modules/derby/node_modules/racer/node_modules/share/node_modules/ottypes/lib/json0.js:240:21)
    at Doc._otApply (/var/lever/hire2/node_modules/derby/node_modules/racer/node_modules/share/lib/client/doc.js:667:12)
    at Doc._onMessage (/var/lever/hire2/node_modules/derby/node_modules/racer/node_modules/share/lib/client/doc.js:379:12)
    at Connection.handleMessage (/var/lever/hire2/node_modules/derby/node_modules/racer/node_modules/share/lib/client/connection.js:215:37)
    at StreamSocket.socket.onmessage (/var/lever/hire2/node_modules/derby/node_modules/racer/node_modules/share/lib/client/connection.js:124:18)
    at StreamSocket.Channel.socket.onmessage (/var/lever/hire2/node_modules/derby/node_modules/racer/lib/Channel.js:19:28)
    at Duplex._write (/var/lever/hire2/node_modules/derby/node_modules/racer/lib/Model/connection.server.js:23:12)