### PR TITLE
Fix transformComponent to handle subtypes that do not return arrays

### DIFF
--- a/lib/json0.js
+++ b/lib/json0.js
@@ -444,20 +444,18 @@ json.transformComponent = function(dest, c, otherC, type) {
       if (c.t && c.t === oc.t) {
         var res = subtypes[c.t].transform(c.o, oc.o, type);
 
-        if (res.length > 0) {
-          // convert back to old string ops
-          if (c.si != null || c.sd != null) {
-            var p = c.p;
-            for (var i = 0; i < res.length; i++) {
-              c.o = [res[i]];
-              c.p = p.slice();
-              convertToText(c);
-              json.append(dest, c);
-            }
-          } else {
-            c.o = res;
+        // convert back to old string ops
+        if (c.si != null || c.sd != null) {
+          var p = c.p;
+          for (var i = 0; i < res.length; i++) {
+            c.o = [res[i]];
+            c.p = p.slice();
+            convertToText(c);
             json.append(dest, c);
           }
+        } else if (!isArray(res) || res.length > 0) {
+          c.o = res;
+          json.append(dest, c);
         }
 
         return dest;

--- a/test/json0.coffee
+++ b/test/json0.coffee
@@ -5,6 +5,11 @@ nativetype = require '../lib/json0'
 
 fuzzer = require 'ot-fuzzer'
 
+nativetype.registerSubtype
+  name: 'mock'
+  transform: (a, b, side) ->
+    return { mock: true }
+
 # Cross-transform helper function. Transform server by client and client by
 # server. Returns [server, client].
 transformX = (type, left, right) ->
@@ -95,6 +100,13 @@ genTests = (type) ->
 
       it 'does not throw errors with blank inserts', ->
         assert.deepEqual type.transform([{p:['k'], t:'text0', o:[{p:5, i:''}]}], [{p:['k'], t:'text0', o:[{p:3, i:'a'}]}], 'left'), []
+
+  describe 'subtype with non-array operation', ->
+    describe '#transform()', ->
+      it 'works', ->
+        a = [{p:[], t:'mock', o:'foo'}]
+        b = [{p:[], t:'mock', o:'bar'}]
+        assert.deepEqual type.transform(a, b, 'left'), [{p:[], t:'mock', o:{mock:true}}]
 
   describe 'list', ->
     describe 'apply', ->


### PR DESCRIPTION
Needed to support `rich-text` for `transform()`. `rich-text`'s transform function returns an object that does not pass a `res.length > 0` test, and so is not appended correctly to `dest`.

This changes the logic to only perform the `res.length > 0` test if `res` is an Array.

Some failing code that is now fixed:

```javascript
var assert = require('assert');
var ot = require('ot-json0').type;
var a = [{ p: ['x'], t: 'rich-text', o: { ops: [{ insert: 'a' }] } }];
var b = [{ p: ['x'], t: 'rich-text', o: { ops: [{ insert: 'b' }] } }];
var t = [{ p: ['x'], t: 'rich-text', o: { ops: [{ retain: 1 }, { insert: 'a' }] } }];
ot.registerSubtype(require('rich-text').type);
assert.deepEqual(ot.transform(a, b, 'left'), t);
```