### PR TITLE
Add type check in string inject function

### DIFF
--- a/lib/text0.js
+++ b/lib/text0.js
@@ -34,6 +34,9 @@ var text = module.exports = {
 
 /** Insert s2 into s1 at pos. */
 var strInject = function(s1, pos, s2) {
+  if (typeof s1 !== 'string') {
+    throw new Error('Source must be a string');    
+  }  
   return s1.slice(0, pos) + s2 + s1.slice(pos);
 };
 


### PR DESCRIPTION
Got an "Uncaught TypeError" when `s1` param wasn't a string (e.g. a boolean value)
