### PR TITLE
Additional validation for operations + shallow copies when applying operations

### DIFF
--- a/lib/json0.js
+++ b/lib/json0.js
@@ -13,60 +13,60 @@ var assert = require('assert');
  */
 
 var updateIn = function(obj, path, callback) {
-    const newObject = shallowCopy(obj);
-    let elem = newObject;
-    for (let i = 0; i < path.length - 1; i++) {
-        const key = path[i];
+    var newObject = shallowCopy(obj);
+    var elem = newObject;
+    for (var i = 0; i < path.length - 1; i++) {
+        var key = path[i];
         elem[key] = shallowCopy(elem[key]);
         elem = elem[key];
     }
-    const lastKey = path[path.length - 1];
+    var lastKey = path[path.length - 1];
     elem[lastKey] = callback(elem[lastKey]);
     return newObject;
 };
 
 var getIn = function(obj, path) {
-    let elem = obj;
-    for (const key of path) {
+    var elem = obj;
+    for (var key of path) {
         elem = elem[key];
     }
     return elem;
 };
 
 var deleteIn = function(obj, path) {
-    const newObject = shallowCopy(obj);
-    let elem = newObject;
-    for (let i = 0; i < path.length - 1; i++) {
-        const key = path[i];
+    var newObject = shallowCopy(obj);
+    var elem = newObject;
+    for (var i = 0; i < path.length - 1; i++) {
+        var key = path[i];
         elem[key] = shallowCopy(elem[key]);
         elem = elem[key];
     }
-    const lastKey = path[path.length - 1];
+    var lastKey = path[path.length - 1];
     delete elem[lastKey];
     return newObject;
 };
 
 var arraySet = function(arr, index, newValue) {
-    const res = arr.slice();
+    var res = arr.slice();
     res[index] = newValue;
     return res;
 };
 
 var arrayInsert = function(arr, index, newValue) {
-    const res = arr.slice();
+    var res = arr.slice();
     res.splice(index, 0, newValue);
     return res;
 };
 
 var arrayDelete = function(arr, index) {
-    const res = arr.slice();
+    var res = arr.slice();
     res.splice(index, 1);
     return res;
 };
 
 var arrayMove = function(arr, fromIndex, toIndex) {
-    const res = arr.slice();
-    const elem = res[fromIndex];
+    var res = arr.slice();
+    var elem = res[fromIndex];
     res.splice(fromIndex, 1); // remove it
     res.splice(toIndex, 0, elem); // add it back
     return res;
@@ -218,14 +218,14 @@ json.apply = function(snapshot, op) {
   op = clone(op);
 
   // wrap in an object so the actual `snapshot` can be a primitive
-  let _snapshot = {snapshot};
+  var _snapshot = {snapshot: snapshot};
 
   for (var i = 0; i < op.length; i++) {
     var c = op[i];
 
-    const fullPath = ['snapshot', ...c.p];
-    const pathToParent = fullPath.slice(0, -1);
-    const index = fullPath[fullPath.length - 1];
+    var fullPath = ['snapshot', ...c.p];
+    var pathToParent = fullPath.slice(0, -1);
+    var index = fullPath[fullPath.length - 1];
 
     // convert old string ops to use subtype for backwards compatibility
     if (c.si != null || c.sd != null) {
@@ -263,7 +263,7 @@ json.apply = function(snapshot, op) {
 
         // can insert at end of the list
         json.checkInRange(index, x.size, 'insert');
-        const e = arrayInsert(x, index, c.li);
+        var e = arrayInsert(x, index, c.li);
         return e;
       });
     }
@@ -301,7 +301,7 @@ json.apply = function(snapshot, op) {
 
     // Object insert / replace
     else if (c.oi !== undefined) {
-      const parent = getIn(_snapshot, pathToParent);
+      var parent = getIn(_snapshot, pathToParent);
       _snapshot = updateIn(_snapshot, fullPath, (x) => {
         json.checkObj(parent);
 
@@ -326,12 +326,12 @@ json.apply = function(snapshot, op) {
     // Object delete
     else if (c.od !== undefined) {
 
-      const parent = getIn(_snapshot, pathToParent);
+      var parent = getIn(_snapshot, pathToParent);
       if (parent == null) {
         throw new Error('Cannot delete from null');
       }
 
-      const toDelete = getIn(_snapshot, fullPath);
+      var toDelete = getIn(_snapshot, fullPath);
       assert.deepEqual(toDelete, c.od, "Deleting the wrong object." +
         " Expected " + JSON.stringify(c.od) + " deepEqual " + JSON.stringify(toDelete));
 

--- a/lib/json0.js
+++ b/lib/json0.js
@@ -1,4 +1,5 @@
 var assert = require('assert');
+
 /*
  This is the implementation of the JSON OT type.
 
@@ -11,6 +12,76 @@ var assert = require('assert');
  * UTILITY FUNCTIONS
  */
 
+var updateIn = function(obj, path, callback) {
+    const newObject = shallowCopy(obj);
+    let elem = newObject;
+    for (let i = 0; i < path.length - 1; i++) {
+        const key = path[i];
+        elem[key] = shallowCopy(elem[key]);
+        elem = elem[key];
+    }
+    const lastKey = path[path.length - 1];
+    elem[lastKey] = callback(elem[lastKey]);
+    return newObject;
+};
+
+var getIn = function(obj, path) {
+    let elem = obj;
+    for (const key of path) {
+        elem = elem[key];
+    }
+    return elem;
+};
+
+var deleteIn = function(obj, path) {
+    const newObject = shallowCopy(obj);
+    let elem = newObject;
+    for (let i = 0; i < path.length - 1; i++) {
+        const key = path[i];
+        elem[key] = shallowCopy(elem[key]);
+        elem = elem[key];
+    }
+    const lastKey = path[path.length - 1];
+    delete elem[lastKey];
+    return newObject;
+};
+
+var arraySet = function(arr, index, newValue) {
+    const res = arr.slice();
+    res[index] = newValue;
+    return res;
+};
+
+var arrayInsert = function(arr, index, newValue) {
+    const res = arr.slice();
+    res.splice(index, 0, newValue);
+    return res;
+};
+
+var arrayDelete = function(arr, index) {
+    const res = arr.slice();
+    res.splice(index, 1);
+    return res;
+};
+
+var arrayMove = function(arr, fromIndex, toIndex) {
+    const res = arr.slice();
+    const elem = res[fromIndex];
+    res.splice(fromIndex, 1); // remove it
+    res.splice(toIndex, 0, elem); // add it back
+    return res;
+};
+
+var shallowCopy = function(obj) {
+    if (isArray(obj)) {
+        return obj.slice();
+    } else if (typeof obj === 'object') {
+        return Object.assign({}, obj);
+    } else {
+        throw new Error('Cannot make shallow copy of ' + obj);
+    }
+};
+
 /**
  * Checks if the passed object is an Array instance. Can't use Array.isArray
  * yet because its not supported on IE8.
@@ -19,7 +90,7 @@ var assert = require('assert');
  * @returns {boolean}
  */
 var isArray = function(obj) {
-  return Object.prototype.toString.call(obj) == '[object Array]';
+  return Object.prototype.toString.call(obj) === '[object Array]';
 };
 
 /**
@@ -122,7 +193,7 @@ json.checkInRange = function(index, max, opName) {
     throw new Error("Referenced element is not in range. (" +
       "Cannot '" + opName + "' index:" + index + ", max:" + max + ")");
   }
-}
+};
 
 // helper functions to convert old string ops to and from subtype ops
 function convertFromText(c) {
@@ -146,118 +217,125 @@ json.apply = function(snapshot, op) {
 
   op = clone(op);
 
-  var container = {
-    data: snapshot
-  };
+  // wrap in an object so the actual `snapshot` can be a primitive
+  let _snapshot = {snapshot};
 
   for (var i = 0; i < op.length; i++) {
     var c = op[i];
 
+    const fullPath = ['snapshot', ...c.p];
+    const pathToParent = fullPath.slice(0, -1);
+    const index = fullPath[fullPath.length - 1];
+
     // convert old string ops to use subtype for backwards compatibility
-    if (c.si != null || c.sd != null)
+    if (c.si != null || c.sd != null) {
       convertFromText(c);
-
-    var parent = null;
-    var parentKey = null;
-    var elem = container;
-    var key = 'data';
-
-    for (var j = 0; j < c.p.length; j++) {
-      var p = c.p[j];
-
-      parent = elem;
-      parentKey = key;
-      elem = elem[key];
-      key = p;
-
-      if (parent == null)
-        throw new Error('Path invalid');
+      fullPath.pop();
     }
 
     // handle subtype ops
-    if (c.t && c.o !== void 0 && subtypes[c.t]) {
-      elem[key] = subtypes[c.t].apply(elem[key], c.o);
+    if (c.t && c.o !== undefined && subtypes[c.t]) {
+      _snapshot = updateIn(_snapshot, fullPath, (x) => subtypes[c.t].apply(x, c.o));
 
     // Number add
-    } else if (c.na !== void 0) {
-      if (typeof elem[key] != 'number')
-        throw new Error('Referenced element not a number');
-
-      elem[key] += c.na;
+    } else if (c.na !== undefined) {
+      _snapshot = updateIn(_snapshot, fullPath, (x) => {
+        if (typeof x !== 'number') {
+          throw new Error('Referenced element not a number');
+        }
+        return x + c.na;
+      });
     }
-
     // List replace
-    else if (c.li !== void 0 && c.ld !== void 0) {
-      json.checkList(elem);
-      // Should check the list element matches c.ld
-      json.checkInRange(key, elem.length-1, 'replace');
+    else if (c.li !== undefined && c.ld !== undefined) {
+      _snapshot = updateIn(_snapshot, pathToParent, (x) => {
+        json.checkList(x);
 
-      elem[key] = c.li;
+        // Should check the list element matches c.ld
+        json.checkInRange(index, x.size-1, 'replace');
+        return arraySet(x, index, c.li);
+      });
     }
-
     // List insert
-    else if (c.li !== void 0) {
-      json.checkList(elem);
+    else if (c.li !== undefined) {
+      _snapshot = updateIn(_snapshot, pathToParent, (x) => {
+        json.checkList(x);
 
-      // can insert at end of the list
-      json.checkInRange(key, elem.length, 'insert');
-      elem.splice(key,0, c.li);
+        // can insert at end of the list
+        json.checkInRange(index, x.size, 'insert');
+        const e = arrayInsert(x, index, c.li);
+        return e;
+      });
     }
 
     // List delete
-    else if (c.ld !== void 0) {
-      json.checkList(elem);
-      json.checkInRange(key, elem.length-1, 'delete');
+    else if (c.ld !== undefined) {
+      _snapshot = updateIn(_snapshot, pathToParent, (x) => {
+        json.checkList(x);
 
-      assert.deepEqual(elem[key], c.ld, "Deleting the wrong object from the list." +
-        " Expected " + JSON.stringify(c.ld) + " deepEqual " + JSON.stringify(elem[key]));
+        // can insert at end of the list
+        json.checkInRange(index, x.size-1, 'delete');
 
-      // Should check the list element matches c.ld here too.
-      elem.splice(key,1);
+        assert.deepEqual(x[index], c.ld, "Deleting the wrong object from the list." +
+          " Expected " + JSON.stringify(c.ld) + " deepEqual " + JSON.stringify(x[index]));
+
+        return arrayDelete(x, index);
+      });
     }
 
     // List move
-    else if (c.lm !== void 0) {
-      json.checkList(elem);
-      if (c.lm != key) {
-        json.checkInRange(key, elem.length-1, 'move from');
-        json.checkInRange(c.lm, elem.length-1, 'move to');
+    else if (c.lm !== undefined) {
+      _snapshot = updateIn(_snapshot, pathToParent, (x) => {
+        json.checkList(x);
 
-        var e = elem[key];
-        // Remove it...
-        elem.splice(key,1);
-        // And insert it back.
-        elem.splice(c.lm,0,e);
-      }
+        if (c.lm !== index) {
+          json.checkInRange(index, x.size-1, 'move from');
+          json.checkInRange(c.lm, x.size-1, 'move to');
+
+          return arrayMove(x, index, c.lm);
+        }
+        return x;
+      });
+
     }
 
     // Object insert / replace
-    else if (c.oi !== void 0) {
-      json.checkObj(elem);
+    else if (c.oi !== undefined) {
+      const parent = getIn(_snapshot, pathToParent);
+      _snapshot = updateIn(_snapshot, fullPath, (x) => {
+        json.checkObj(parent);
 
-      if ('od' in c) {
-        // `od` + `oi` means replace or update. If the old value
-        // does not equal the current value, there was an error
-        // in the transformation.
-        assert.deepEqual(elem[key], c.od, "Deleting the wrong object." +
-          " Expected " + JSON.stringify(c.od) + " deepEqual " + JSON.stringify(elem[key]));
-      }
+        if ('od' in c) {
+          // `od` + `oi` means replace or update. If the old value
+          // does not equal the current value, there was an error
+          // in the transformation.
+          assert.deepEqual(x, c.od, "Deleting the wrong object." +
+            " Expected " + JSON.stringify(c.od) + " deepEqual " + JSON.stringify(x));
+        }
 
-      if ((key in elem) && !('od' in c)) {
-        // the operation is overwriting data but not updating the data. The old
-        // value that is being replaced needs to be included in the `od`.
-        throw new Error("Cannot overwrite data w/out replacing it.");
-      }
+        if (parent[index] && !('od' in c)) {
+          // the operation is overwriting data but not updating the data. The old
+          // value that is being replaced needs to be included in the `od`.
+          throw new Error("Cannot overwrite data w/out replacing it.");
+        }
 
-      elem[key] = c.oi;
+        return c.oi;
+      });
     }
 
     // Object delete
-    else if (c.od !== void 0) {
-      json.checkObj(elem);
+    else if (c.od !== undefined) {
 
-      // Should check that elem[key] == c.od
-      delete elem[key];
+      const parent = getIn(_snapshot, pathToParent);
+      if (parent == null) {
+        throw new Error('Cannot delete from null');
+      }
+
+      const toDelete = getIn(_snapshot, fullPath);
+      assert.deepEqual(toDelete, c.od, "Deleting the wrong object." +
+        " Expected " + JSON.stringify(c.od) + " deepEqual " + JSON.stringify(toDelete));
+
+      _snapshot = deleteIn(_snapshot, fullPath);
     }
 
     else {
@@ -265,7 +343,7 @@ json.apply = function(snapshot, op) {
     }
   }
 
-  return container.data;
+  return _snapshot.snapshot;
 };
 
 // Helper to break an operation up into a bunch of small ops.
@@ -699,4 +777,3 @@ var text = require('./text0');
 
 json.registerSubtype(text);
 module.exports = json;
-

--- a/lib/json0.js
+++ b/lib/json0.js
@@ -646,7 +646,12 @@ json.transformComponent = function(dest, c, otherC, type) {
       if (c.oi !== void 0 && c.p[common] === otherC.p[common]) {
         // left wins if we try to insert at the same place
         if (type === 'left') {
-          json.append(dest,{p: c.p, od:otherC.oi});
+          // clone c to keep any additional properties attached to the operation.
+          var clonedC = clone(c);
+          clonedC.od = otherC.oi;
+          delete clonedC.oi;
+
+          json.append(dest, clonedC);
         } else {
           return dest;
         }

--- a/lib/json0.js
+++ b/lib/json0.js
@@ -209,7 +209,8 @@ json.apply = function(snapshot, op) {
       json.checkList(elem);
       json.checkInRange(key, elem.length-1, 'delete');
 
-      assert.deepEqual(elem[key], c.ld, "Deleting the wrong object from the list.")
+      assert.deepEqual(elem[key], c.ld, "Deleting the wrong object from the list." +
+        " Expected " + JSON.stringify(c.ld) + " deepEqual " + JSON.stringify(elem[key]));
 
       // Should check the list element matches c.ld here too.
       elem.splice(key,1);
@@ -238,7 +239,8 @@ json.apply = function(snapshot, op) {
         // `od` + `oi` means replace or update. If the old value
         // does not equal the current value, there was an error
         // in the transformation.
-        assert.deepEqual(elem[key], c.od, "Deleting the wrong object.")
+        assert.deepEqual(elem[key], c.od, "Deleting the wrong object." +
+          " Expected " + JSON.stringify(c.od) + " deepEqual " + JSON.stringify(elem[key]));
       }
 
       if ((key in elem) && !('od' in c)) {

--- a/lib/json0.js
+++ b/lib/json0.js
@@ -12,6 +12,34 @@ var assert = require('assert');
  * UTILITY FUNCTIONS
  */
 
+/*
+ * https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/Object/assign
+*/
+if (typeof Object.assign != 'function') {
+  Object.assign = function (target, varArgs) { // .length of function is 2
+    'use strict';
+    if (target == null) { // TypeError if undefined or null
+      throw new TypeError('Cannot convert undefined or null to object');
+    }
+
+    var to = Object(target);
+
+    for (var index = 1; index < arguments.length; index++) {
+      var nextSource = arguments[index];
+
+      if (nextSource != null) { // Skip over if undefined or null
+        for (var nextKey in nextSource) {
+          // Avoid bugs when hasOwnProperty is shadowed
+          if (Object.prototype.hasOwnProperty.call(nextSource, nextKey)) {
+            to[nextKey] = nextSource[nextKey];
+          }
+        }
+      }
+    }
+    return to;
+  };
+}
+
 var updateIn = function(obj, path, callback) {
     var newObject = shallowCopy(obj);
     var elem = newObject;
@@ -27,7 +55,8 @@ var updateIn = function(obj, path, callback) {
 
 var getIn = function(obj, path) {
     var elem = obj;
-    for (var key of path) {
+    for (var i = 0; i < path.length; i++) {
+        var key = path[i]
         elem = elem[key];
     }
     return elem;
@@ -223,7 +252,8 @@ json.apply = function(snapshot, op) {
   for (var i = 0; i < op.length; i++) {
     var c = op[i];
 
-    var fullPath = ['snapshot', ...c.p];
+    var fullPath = c.p.slice();
+    fullPath.unshift('snapshot');
     var pathToParent = fullPath.slice(0, -1);
     var index = fullPath[fullPath.length - 1];
 
@@ -235,11 +265,13 @@ json.apply = function(snapshot, op) {
 
     // handle subtype ops
     if (c.t && c.o !== undefined && subtypes[c.t]) {
-      _snapshot = updateIn(_snapshot, fullPath, (x) => subtypes[c.t].apply(x, c.o));
+      _snapshot = updateIn(_snapshot, fullPath, function(x) {
+        return subtypes[c.t].apply(x, c.o)
+      });
 
     // Number add
     } else if (c.na !== undefined) {
-      _snapshot = updateIn(_snapshot, fullPath, (x) => {
+      _snapshot = updateIn(_snapshot, fullPath, function(x) {
         if (typeof x !== 'number') {
           throw new Error('Referenced element not a number');
         }
@@ -248,7 +280,7 @@ json.apply = function(snapshot, op) {
     }
     // List replace
     else if (c.li !== undefined && c.ld !== undefined) {
-      _snapshot = updateIn(_snapshot, pathToParent, (x) => {
+      _snapshot = updateIn(_snapshot, pathToParent, function(x) {
         json.checkList(x);
 
         // Should check the list element matches c.ld
@@ -258,7 +290,7 @@ json.apply = function(snapshot, op) {
     }
     // List insert
     else if (c.li !== undefined) {
-      _snapshot = updateIn(_snapshot, pathToParent, (x) => {
+      _snapshot = updateIn(_snapshot, pathToParent, function(x) {
         json.checkList(x);
 
         // can insert at end of the list
@@ -270,7 +302,7 @@ json.apply = function(snapshot, op) {
 
     // List delete
     else if (c.ld !== undefined) {
-      _snapshot = updateIn(_snapshot, pathToParent, (x) => {
+      _snapshot = updateIn(_snapshot, pathToParent, function(x) {
         json.checkList(x);
 
         // can insert at end of the list
@@ -285,7 +317,7 @@ json.apply = function(snapshot, op) {
 
     // List move
     else if (c.lm !== undefined) {
-      _snapshot = updateIn(_snapshot, pathToParent, (x) => {
+      _snapshot = updateIn(_snapshot, pathToParent, function(x) {
         json.checkList(x);
 
         if (c.lm !== index) {
@@ -302,7 +334,7 @@ json.apply = function(snapshot, op) {
     // Object insert / replace
     else if (c.oi !== undefined) {
       var parent = getIn(_snapshot, pathToParent);
-      _snapshot = updateIn(_snapshot, fullPath, (x) => {
+      _snapshot = updateIn(_snapshot, fullPath, function(x) {
         json.checkObj(parent);
 
         if ('od' in c) {

--- a/lib/json0.js
+++ b/lib/json0.js
@@ -116,6 +116,13 @@ json.checkObj = function(elem) {
   }
 };
 
+json.checkInRange = function(index, max, opName) {
+  if (index < 0 || index > max) {
+    throw new Error("Referenced element is not in range. (" +
+      "Cannot '" + opName + "' index:" + index + ", max:" + max + ")");
+  }
+}
+
 // helper functions to convert old string ops to and from subtype ops
 function convertFromText(c) {
   c.t = 'text0';
@@ -182,18 +189,25 @@ json.apply = function(snapshot, op) {
     else if (c.li !== void 0 && c.ld !== void 0) {
       json.checkList(elem);
       // Should check the list element matches c.ld
+      json.checkInRange(key, elem.length-1, 'replace');
+
       elem[key] = c.li;
     }
 
     // List insert
     else if (c.li !== void 0) {
       json.checkList(elem);
+
+      // can insert at end of the list
+      json.checkInRange(key, elem.length, 'insert');
       elem.splice(key,0, c.li);
     }
 
     // List delete
     else if (c.ld !== void 0) {
       json.checkList(elem);
+      json.checkInRange(key, elem.length-1, 'delete');
+
       // Should check the list element matches c.ld here too.
       elem.splice(key,1);
     }
@@ -202,6 +216,9 @@ json.apply = function(snapshot, op) {
     else if (c.lm !== void 0) {
       json.checkList(elem);
       if (c.lm != key) {
+        json.checkInRange(key, elem.length-1, 'move from');
+        json.checkInRange(c.lm, elem.length-1, 'move to');
+
         var e = elem[key];
         // Remove it...
         elem.splice(key,1);


### PR DESCRIPTION
This library is awesome and has been super helpful! In the course of using it, we found it helpful to add some validation to ensure that the operations being submitted are valid and fail fast. This means validating that the `ld` or `od` object is actually the expected object being deleted, range checks for `l*` operations, and that `oi` operations include `od` when they are overwriting/deleting an existing object.

This PR also includes a change to clone the entire operation instead of rebuilding it from scratch. We found places where attaching additional properties to an operation was helpful, and we want to maintain those properties after transforming the operations.

We use `webpack` (and sometimes `browserify`) to include this library on the client side and are able to `require('assert')` but if that doesn't work, I can add a custom `assert.deepEqual()` function to the code.

If this is considered a breaking change (due to the new errors and assertions), I can bump the version number too.

Like I said, this library has been great to work with and I'm happy to contribute back. Let me know if these changes look good or if they require additional modification.

Thanks!
