### PR TITLE
[WIP] transformCursor implementation

### DIFF
--- a/lib/json0.js
+++ b/lib/json0.js
@@ -651,6 +651,40 @@ json.transformComponent = function(dest, c, otherC, type) {
   return dest;
 };
 
+json.transformPosition = function(cursor, op, isOwnOp) {
+  var cursor = clone(cursor)
+
+  var opIsAncestor = (cursor.length > op.p.length)
+  var opIsSibling = (cursor.length === op.p.length)
+  // TODO need one for ancestor sibling
+  for (var i = 0; i < op.p.length; i++) {
+    if (op.p[i] !== cursor[i]) {
+      opIsAncestor = false
+      if (i < op.p.length-1) {
+        opIsSibling = false
+      }
+    }
+  }
+
+  if (opIsSibling) {
+    if (op.sd) {
+      cursor[cursor.length-1] = text.transformCursor(cursor[cursor.length-1], [{p: op.p[op.p.length-1], d: op.sd}], isOwnOp ? 'right' : 'left')
+    }
+    if (op.si) {
+      cursor[cursor.length-1] = text.transformCursor(cursor[cursor.length-1], [{p: op.p[op.p.length-1], i: op.si}], isOwnOp ? 'right': 'left')
+    }
+  }
+
+  return cursor
+}
+
+json.transformCursor = function(cursor, op, isOwnOp) {
+  for (var i = 0; i < op.length; i++) {
+    cursor = transformPosition(cursor, op[i], isOwnOp);
+  }
+  return cursor;
+}
+
 require('./bootstrapTransform')(json, json.transformComponent, json.checkValidOp, json.append);
 
 /**

--- a/lib/json0.js
+++ b/lib/json0.js
@@ -656,7 +656,7 @@ json.transformPosition = function(cursor, op, isOwnOp) {
 
   var opIsAncestor = (cursor.length >= op.p.length) // true also if op is self
   var opIsSibling = (cursor.length === op.p.length) // true also if op is self
-  var opIsAncestorSibling = (cursor.length > op.p.length) // true also if op is self or sibling of self
+  var opIsAncestorSibling = (cursor.length >= op.p.length) // true also if op is self or sibling of self
   var equalUpTo = -1
   for (var i = 0; i < op.p.length; i++) {
     if (op.p[i] !== cursor[i]) {
@@ -681,13 +681,34 @@ json.transformPosition = function(cursor, op, isOwnOp) {
   }
 
   if (opIsAncestor) {
-    if (op.lm) {
+    if (op.lm !== undefined) {
       cursor[equalUpTo] = op.lm
     }
     if (op.od && op.oi) {
       cursor = op.p.slice(0, op.p.length)
     } else if (op.od) {
       cursor = op.p.slice(0,op.p.length-1)
+    } else if (op.ld && op.li) {
+      cursor = op.p.slice(0, op.p.length)
+    } else if (op.ld) {
+      cursor = op.p.slice(0, op.p.length-1)
+    }
+  }
+
+  if (opIsAncestorSibling) {
+    var lastPathIdx = op.p.length-1
+    if (!opIsAncestor && op.ld && !op.li && op.p[lastPathIdx] < cursor[lastPathIdx]) {
+      cursor[lastPathIdx] -= 1
+    } else if (!op.ld && op.li && op.p[lastPathIdx] <= cursor[lastPathIdx]) {
+      cursor[lastPathIdx] += 1
+    }
+
+    // if move item in list from after to before
+    if (!opIsAncestor && op.lm !== undefined && op.p[lastPathIdx] > cursor[lastPathIdx] && op.lm <= cursor[lastPathIdx]) {
+      cursor[lastPathIdx] += 1
+    // if move item in list from before to after
+    } else if (!opIsAncestor && op.lm !== undefined && op.p[lastPathIdx] < cursor[lastPathIdx] && op.lm >= cursor[lastPathIdx]) {
+      cursor[lastPathIdx] -= 1
     }
   }
 

--- a/lib/json0.js
+++ b/lib/json0.js
@@ -654,15 +654,20 @@ json.transformComponent = function(dest, c, otherC, type) {
 json.transformPosition = function(cursor, op, isOwnOp) {
   var cursor = clone(cursor)
 
-  var opIsAncestor = (cursor.length > op.p.length)
-  var opIsSibling = (cursor.length === op.p.length)
-  // TODO need one for ancestor sibling
+  var opIsAncestor = (cursor.length >= op.p.length) // true also if op is self
+  var opIsSibling = (cursor.length === op.p.length) // true also if op is self
+  var opIsAncestorSibling = (cursor.length > op.p.length) // true also if op is self or sibling of self
+  var equalUpTo = -1
   for (var i = 0; i < op.p.length; i++) {
     if (op.p[i] !== cursor[i]) {
       opIsAncestor = false
       if (i < op.p.length-1) {
         opIsSibling = false
+        opIsAncestorSibling = false
       }
+    }
+    if (equalUpTo === i-1 && op.p[i] === cursor[i]) {
+      equalUpTo += 1
     }
   }
 
@@ -672,6 +677,17 @@ json.transformPosition = function(cursor, op, isOwnOp) {
     }
     if (op.si) {
       cursor[cursor.length-1] = text.transformCursor(cursor[cursor.length-1], [{p: op.p[op.p.length-1], i: op.si}], isOwnOp ? 'right': 'left')
+    }
+  }
+
+  if (opIsAncestor) {
+    if (op.lm) {
+      cursor[equalUpTo] = op.lm
+    }
+    if (op.od && op.oi) {
+      cursor = op.p.slice(0, op.p.length)
+    } else if (op.od) {
+      cursor = op.p.slice(0,op.p.length-1)
     }
   }
 

--- a/lib/json0.js
+++ b/lib/json0.js
@@ -651,7 +651,7 @@ json.transformComponent = function(dest, c, otherC, type) {
   return dest;
 };
 
-json.transformPosition = function(cursor, op, isOwnOp) {
+var transformPosition = function(cursor, op, isOwnOp) {
   var cursor = clone(cursor)
 
   var opIsAncestor = (cursor.length >= op.p.length) // true also if op is self

--- a/test/json0.coffee
+++ b/test/json0.coffee
@@ -389,7 +389,7 @@ genTests = (type) ->
       assert.deepEqual [], type.transform [{p:['k'], od:'x'}], [{p:['k'], od:'x'}], 'left'
       assert.deepEqual [], type.transform [{p:['k'], od:'x'}], [{p:['k'], od:'x'}], 'right'
 
-  describe 'cursor transform', ->
+  describe 'transformCursor', ->
     describe 'string operations', ->
       it 'handles inserts before', ->
         assert.deepEqual ['key', 10, 3+4], type.transformPosition(['key', 10, 3], {p: ['key', 10, 1], si: 'meow'})
@@ -441,10 +441,10 @@ genTests = (type) ->
         assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key2'], od: 'meow'})
       it 'handles deletes at current point', ->
         assert.deepEqual [], type.transformPosition(['key', 0, 3], {p: ['key'], od: ['meow123']})
-        assert.deepEqual ['key', 10], type.transformPosition(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123']})
+        assert.deepEqual ['key', 0], type.transformPosition(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123']})
       it 'handles replacements at current point', ->
         assert.deepEqual ['key'], type.transformPosition(['key', 0, 3], {p: ['key'], od: ['meow123'], oi: 'newobj'})
-        assert.deepEqual ['key', 10, 'key2'], type.transformPosition(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123'], oi: 'newobj'})
+        assert.deepEqual ['key', 0, 'key2'], type.transformPosition(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123'], oi: 'newobj'})
     describe 'subtype operations', ->
       it 'warns that they are unsupported', ->
         assert.throws(->

--- a/test/json0.coffee
+++ b/test/json0.coffee
@@ -449,11 +449,6 @@ genTests = (type) ->
       it 'handles replacements at current point', ->
         assert.deepEqual ['key'], type.transformCursor(['key', 0, 3], [{p: ['key'], od: ['meow123'], oi: 'newobj'}])
         assert.deepEqual ['key', 0, 'key2'], type.transformCursor(['key', 0, 'key2'], [{p: ['key', 0, 'key2'], od: ['meow123'], oi: 'newobj'}])
-    describe 'subtype operations', ->
-      it 'warns that they are unsupported', ->
-        assert.throws(->
-          type.transformCursor(['key', 10, 3], [{p: ['key', 10, 3], t: 'text0', o: 'testop'}])
-        , /subtype.*unsupported/)
 
   describe 'randomizer', ->
     @timeout 20000

--- a/test/json0.coffee
+++ b/test/json0.coffee
@@ -389,66 +389,66 @@ genTests = (type) ->
       assert.deepEqual [], type.transform [{p:['k'], od:'x'}], [{p:['k'], od:'x'}], 'left'
       assert.deepEqual [], type.transform [{p:['k'], od:'x'}], [{p:['k'], od:'x'}], 'right'
 
-  describe 'cursor', ->
+  describe 'cursor transform', ->
     describe 'string operations', ->
       it 'handles inserts before', ->
-        assert.deepEqual ['key', 10, 3+4], type.transformCursor(['key', 10, 3], {p: ['key', 10, 1], si: 'meow'})
+        assert.deepEqual ['key', 10, 3+4], type.transformPosition(['key', 10, 3], {p: ['key', 10, 1], si: 'meow'})
       it 'handles inserts after', ->
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 5], si: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 5], si: 'meow'})
       it 'handles inserts at current point with isOwnOp', ->
-        assert.deepEqual ['key', 10, 3+4], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], si: 'meow'}, true)
+        assert.deepEqual ['key', 10, 3+4], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], si: 'meow'}, true)
       it 'handles inserts at current point without isOwnOp', ->
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], si: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], si: 'meow'})
       it 'handles deletes before', ->
-        assert.deepEqual ['key', 10, 3-2], type.transformCursor(['key', 10, 3], {p: ['key', 10, 0], sd: '12'})
+        assert.deepEqual ['key', 10, 3-2], type.transformPosition(['key', 10, 3], {p: ['key', 10, 0], sd: '12'})
       it 'handles deletes after', ->
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], sd: '12'})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], sd: '12'})
       it 'handles deletes at current point', ->
-        assert.deepEqual ['key', 10, 1], type.transformCursor(['key', 10, 3], {p: ['key', 10, 1], sd: 'meow meow'})
+        assert.deepEqual ['key', 10, 1], type.transformPosition(['key', 10, 3], {p: ['key', 10, 1], sd: 'meow meow'})
       it 'ignores irrelevant operations', ->
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 9, 1], si: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 9, 1], si: 'meow'})
     describe 'number operations', ->
       it 'ignores', ->
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], na: 123})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], na: 123})
     describe 'list operations', ->
       it 'handles inserts before', ->
-        assert.deepEqual ['key', 10, 3+1], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], li: 'meow'})
-        assert.deepEqual ['key', 10+1, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10], li: 'meow'})
+        assert.deepEqual ['key', 10, 3+1], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], li: 'meow'})
+        assert.deepEqual ['key', 10+1, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10], li: 'meow'})
       it 'handles inserts after', ->
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 4], li: 'meow'})
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 11], li: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 4], li: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 11], li: 'meow'})
       it 'handles replacements at current point', ->
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], ld: 'meow1', li: 'meow2'})
-        assert.deepEqual ['key', 10], type.transformCursor(['key', 10, 3], {p: ['key', 10], ld: 'meow1', li: 'meow2'}) # move cursor up tree when parent deleted
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], ld: 'meow1', li: 'meow2'})
+        assert.deepEqual ['key', 10], type.transformPosition(['key', 10, 3], {p: ['key', 10], ld: 'meow1', li: 'meow2'}) # move cursor up tree when parent deleted
       it 'handles deletes before', ->
-        assert.deepEqual ['key', 10, 3-1], type.transformCursor(['key', 10, 3], {p: ['key', 10, 2], ld: 'meow'})
-        assert.deepEqual ['key', 10-1, 3], type.transformCursor(['key', 10, 3], {p: ['key', 9], ld: 'meow'})
+        assert.deepEqual ['key', 10, 3-1], type.transformPosition(['key', 10, 3], {p: ['key', 10, 2], ld: 'meow'})
+        assert.deepEqual ['key', 10-1, 3], type.transformPosition(['key', 10, 3], {p: ['key', 9], ld: 'meow'})
       it 'handles deletes after', ->
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 4], ld: 'meow'})
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 11], ld: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 4], ld: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 11], ld: 'meow'})
       it 'handles deletes at current point', ->
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], ld: 'meow'})
-        assert.deepEqual ['key', 10], type.transformCursor(['key', 10, 3], {p: ['key', 10], ld: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], ld: 'meow'})
+        assert.deepEqual ['key', 10], type.transformPosition(['key', 10, 3], {p: ['key', 10], ld: 'meow'})
       it 'handles movements of current point', ->
-        assert.deepEqual ['key', 10, 20], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], lm: 20})
-        assert.deepEqual ['key', 20, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10], lm: 20})
+        assert.deepEqual ['key', 10, 20], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], lm: 20})
+        assert.deepEqual ['key', 20, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10], lm: 20})
       it 'ignores irrelevant operations', ->
-        assert.deepEqual ['key', 10, 20], type.transformCursor(['key', 10, 3], {p: ['key', 10, 2], lm: 20})
-        assert.deepEqual ['key', 20, 3], type.transformCursor(['key', 10, 3], {p: ['key', 9], lm: 20})
+        assert.deepEqual ['key', 10, 20], type.transformPosition(['key', 10, 3], {p: ['key', 10, 2], lm: 20})
+        assert.deepEqual ['key', 20, 3], type.transformPosition(['key', 10, 3], {p: ['key', 9], lm: 20})
     describe 'dict operations', ->
       it 'ignores irrelevant inserts and deletes', ->
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key2'], oi: 'meow'})
-        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key2'], od: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key2'], oi: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key2'], od: 'meow'})
       it 'handles deletes at current point', ->
-        assert.deepEqual [], type.transformCursor(['key', 0, 3], {p: ['key'], od: ['meow123']})
-        assert.deepEqual ['key', 10], type.transformCursor(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123']})
+        assert.deepEqual [], type.transformPosition(['key', 0, 3], {p: ['key'], od: ['meow123']})
+        assert.deepEqual ['key', 10], type.transformPosition(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123']})
       it 'handles replacements at current point', ->
-        assert.deepEqual ['key'], type.transformCursor(['key', 0, 3], {p: ['key'], od: ['meow123'], oi: 'newobj'})
-        assert.deepEqual ['key', 10, 'key2'], type.transformCursor(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123'], oi: 'newobj'})
+        assert.deepEqual ['key'], type.transformPosition(['key', 0, 3], {p: ['key'], od: ['meow123'], oi: 'newobj'})
+        assert.deepEqual ['key', 10, 'key2'], type.transformPosition(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123'], oi: 'newobj'})
     describe 'subtype operations', ->
       it 'warns that they are unsupported', ->
         assert.throws(->
-          type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], t: 'text0', o: 'testop'})
+          type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], t: 'text0', o: 'testop'})
         , /subtype.*unsupported/)
 
   describe 'randomizer', ->

--- a/test/json0.coffee
+++ b/test/json0.coffee
@@ -427,14 +427,18 @@ genTests = (type) ->
         assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 4], ld: 'meow'})
         assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 11], ld: 'meow'})
       it 'handles deletes at current point', ->
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], ld: 'meow'})
-        assert.deepEqual ['key', 10], type.transformPosition(['key', 10, 3], {p: ['key', 10], ld: 'meow'})
+        assert.deepEqual ['key', 10], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], ld: 'meow'})
+        assert.deepEqual ['key'], type.transformPosition(['key', 10, 3], {p: ['key', 10], ld: 'meow'})
       it 'handles movements of current point', ->
         assert.deepEqual ['key', 10, 20], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], lm: 20})
         assert.deepEqual ['key', 20, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10], lm: 20})
-      it 'ignores irrelevant operations', ->
-        assert.deepEqual ['key', 10, 20], type.transformPosition(['key', 10, 3], {p: ['key', 10, 2], lm: 20})
-        assert.deepEqual ['key', 20, 3], type.transformPosition(['key', 10, 3], {p: ['key', 9], lm: 20})
+      it 'handles movements of other points', ->
+        assert.deepEqual ['key', 10, 2], type.transformPosition(['key', 10, 3], {p: ['key', 10, 1], lm: 20})
+        assert.deepEqual ['key', 10, 4], type.transformPosition(['key', 10, 3], {p: ['key', 10, 5], lm: 3})
+        assert.deepEqual ['key', 10, 4], type.transformPosition(['key', 10, 3], {p: ['key', 10, 5], lm: 1})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 10], lm: 20})
+        assert.deepEqual ['key', 10, 2], type.transformPosition(['key', 10, 3], {p: ['key', 10, 2], lm: 3})
+        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 2], lm: 1})
     describe 'dict operations', ->
       it 'ignores irrelevant inserts and deletes', ->
         assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key2'], oi: 'meow'})

--- a/test/json0.coffee
+++ b/test/json0.coffee
@@ -392,67 +392,67 @@ genTests = (type) ->
   describe 'transformCursor', ->
     describe 'string operations', ->
       it 'handles inserts before', ->
-        assert.deepEqual ['key', 10, 3+4], type.transformPosition(['key', 10, 3], {p: ['key', 10, 1], si: 'meow'})
+        assert.deepEqual ['key', 10, 3+4], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 1], si: 'meow'}])
       it 'handles inserts after', ->
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 5], si: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 5], si: 'meow'}])
       it 'handles inserts at current point with isOwnOp', ->
-        assert.deepEqual ['key', 10, 3+4], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], si: 'meow'}, true)
+        assert.deepEqual ['key', 10, 3+4], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 3], si: 'meow'}], true)
       it 'handles inserts at current point without isOwnOp', ->
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], si: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 3], si: 'meow'}])
       it 'handles deletes before', ->
-        assert.deepEqual ['key', 10, 3-2], type.transformPosition(['key', 10, 3], {p: ['key', 10, 0], sd: '12'})
+        assert.deepEqual ['key', 10, 3-2], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 0], sd: '12'}])
       it 'handles deletes after', ->
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], sd: '12'})
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 3], sd: '12'}])
       it 'handles deletes at current point', ->
-        assert.deepEqual ['key', 10, 1], type.transformPosition(['key', 10, 3], {p: ['key', 10, 1], sd: 'meow meow'})
+        assert.deepEqual ['key', 10, 1], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 1], sd: 'meow meow'}])
       it 'ignores irrelevant operations', ->
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 9, 1], si: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 9, 1], si: 'meow'}])
     describe 'number operations', ->
       it 'ignores', ->
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], na: 123})
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 3], na: 123}])
     describe 'list operations', ->
       it 'handles inserts before', ->
-        assert.deepEqual ['key', 10, 3+1], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], li: 'meow'})
-        assert.deepEqual ['key', 10+1, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10], li: 'meow'})
+        assert.deepEqual ['key', 10, 3+1], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 3], li: 'meow'}])
+        assert.deepEqual ['key', 10+1, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 10], li: 'meow'}])
       it 'handles inserts after', ->
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 4], li: 'meow'})
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 11], li: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 4], li: 'meow'}])
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 11], li: 'meow'}])
       it 'handles replacements at current point', ->
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], ld: 'meow1', li: 'meow2'})
-        assert.deepEqual ['key', 10], type.transformPosition(['key', 10, 3], {p: ['key', 10], ld: 'meow1', li: 'meow2'}) # move cursor up tree when parent deleted
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 3], ld: 'meow1', li: 'meow2'}])
+        assert.deepEqual ['key', 10], type.transformCursor(['key', 10, 3], [{p: ['key', 10], ld: 'meow1', li: 'meow2'}]) # move cursor up tree when parent deleted
       it 'handles deletes before', ->
-        assert.deepEqual ['key', 10, 3-1], type.transformPosition(['key', 10, 3], {p: ['key', 10, 2], ld: 'meow'})
-        assert.deepEqual ['key', 10-1, 3], type.transformPosition(['key', 10, 3], {p: ['key', 9], ld: 'meow'})
+        assert.deepEqual ['key', 10, 3-1], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 2], ld: 'meow'}])
+        assert.deepEqual ['key', 10-1, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 9], ld: 'meow'}])
       it 'handles deletes after', ->
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 4], ld: 'meow'})
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 11], ld: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 4], ld: 'meow'}])
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 11], ld: 'meow'}])
       it 'handles deletes at current point', ->
-        assert.deepEqual ['key', 10], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], ld: 'meow'})
-        assert.deepEqual ['key'], type.transformPosition(['key', 10, 3], {p: ['key', 10], ld: 'meow'})
+        assert.deepEqual ['key', 10], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 3], ld: 'meow'}])
+        assert.deepEqual ['key'], type.transformCursor(['key', 10, 3], [{p: ['key', 10], ld: 'meow'}])
       it 'handles movements of current point', ->
-        assert.deepEqual ['key', 10, 20], type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], lm: 20})
-        assert.deepEqual ['key', 20, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10], lm: 20})
+        assert.deepEqual ['key', 10, 20], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 3], lm: 20}])
+        assert.deepEqual ['key', 20, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 10], lm: 20}])
       it 'handles movements of other points', ->
-        assert.deepEqual ['key', 10, 2], type.transformPosition(['key', 10, 3], {p: ['key', 10, 1], lm: 20})
-        assert.deepEqual ['key', 10, 4], type.transformPosition(['key', 10, 3], {p: ['key', 10, 5], lm: 3})
-        assert.deepEqual ['key', 10, 4], type.transformPosition(['key', 10, 3], {p: ['key', 10, 5], lm: 1})
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 10], lm: 20})
-        assert.deepEqual ['key', 10, 2], type.transformPosition(['key', 10, 3], {p: ['key', 10, 2], lm: 3})
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key', 10, 2], lm: 1})
+        assert.deepEqual ['key', 10, 2], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 1], lm: 20}])
+        assert.deepEqual ['key', 10, 4], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 5], lm: 3}])
+        assert.deepEqual ['key', 10, 4], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 5], lm: 1}])
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 10], lm: 20}])
+        assert.deepEqual ['key', 10, 2], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 2], lm: 3}])
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key', 10, 2], lm: 1}])
     describe 'dict operations', ->
       it 'ignores irrelevant inserts and deletes', ->
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key2'], oi: 'meow'})
-        assert.deepEqual ['key', 10, 3], type.transformPosition(['key', 10, 3], {p: ['key2'], od: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key2'], oi: 'meow'}])
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], [{p: ['key2'], od: 'meow'}])
       it 'handles deletes at current point', ->
-        assert.deepEqual [], type.transformPosition(['key', 0, 3], {p: ['key'], od: ['meow123']})
-        assert.deepEqual ['key', 0], type.transformPosition(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123']})
+        assert.deepEqual [], type.transformCursor(['key', 0, 3], [{p: ['key'], od: ['meow123']}])
+        assert.deepEqual ['key', 0], type.transformCursor(['key', 0, 'key2'], [{p: ['key', 0, 'key2'], od: ['meow123']}])
       it 'handles replacements at current point', ->
-        assert.deepEqual ['key'], type.transformPosition(['key', 0, 3], {p: ['key'], od: ['meow123'], oi: 'newobj'})
-        assert.deepEqual ['key', 0, 'key2'], type.transformPosition(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123'], oi: 'newobj'})
+        assert.deepEqual ['key'], type.transformCursor(['key', 0, 3], [{p: ['key'], od: ['meow123'], oi: 'newobj'}])
+        assert.deepEqual ['key', 0, 'key2'], type.transformCursor(['key', 0, 'key2'], [{p: ['key', 0, 'key2'], od: ['meow123'], oi: 'newobj'}])
     describe 'subtype operations', ->
       it 'warns that they are unsupported', ->
         assert.throws(->
-          type.transformPosition(['key', 10, 3], {p: ['key', 10, 3], t: 'text0', o: 'testop'})
+          type.transformCursor(['key', 10, 3], [{p: ['key', 10, 3], t: 'text0', o: 'testop'}])
         , /subtype.*unsupported/)
 
   describe 'randomizer', ->

--- a/test/json0.coffee
+++ b/test/json0.coffee
@@ -389,6 +389,68 @@ genTests = (type) ->
       assert.deepEqual [], type.transform [{p:['k'], od:'x'}], [{p:['k'], od:'x'}], 'left'
       assert.deepEqual [], type.transform [{p:['k'], od:'x'}], [{p:['k'], od:'x'}], 'right'
 
+  describe 'cursor', ->
+    describe 'string operations', ->
+      it 'handles inserts before', ->
+        assert.deepEqual ['key', 10, 3+4], type.transformCursor(['key', 10, 3], {p: ['key', 10, 1], si: 'meow'})
+      it 'handles inserts after', ->
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 5], si: 'meow'})
+      it 'handles inserts at current point with isOwnOp', ->
+        assert.deepEqual ['key', 10, 3+4], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], si: 'meow'}, true)
+      it 'handles inserts at current point without isOwnOp', ->
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], si: 'meow'})
+      it 'handles deletes before', ->
+        assert.deepEqual ['key', 10, 3-2], type.transformCursor(['key', 10, 3], {p: ['key', 10, 0], sd: '12'})
+      it 'handles deletes after', ->
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], sd: '12'})
+      it 'handles deletes at current point', ->
+        assert.deepEqual ['key', 10, 1], type.transformCursor(['key', 10, 3], {p: ['key', 10, 1], sd: 'meow meow'})
+      it 'ignores irrelevant operations', ->
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 9, 1], si: 'meow'})
+    describe 'number operations', ->
+      it 'ignores', ->
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], na: 123})
+    describe 'list operations', ->
+      it 'handles inserts before', ->
+        assert.deepEqual ['key', 10, 3+1], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], li: 'meow'})
+        assert.deepEqual ['key', 10+1, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10], li: 'meow'})
+      it 'handles inserts after', ->
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 4], li: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 11], li: 'meow'})
+      it 'handles replacements at current point', ->
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], ld: 'meow1', li: 'meow2'})
+        assert.deepEqual ['key', 10], type.transformCursor(['key', 10, 3], {p: ['key', 10], ld: 'meow1', li: 'meow2'}) # move cursor up tree when parent deleted
+      it 'handles deletes before', ->
+        assert.deepEqual ['key', 10, 3-1], type.transformCursor(['key', 10, 3], {p: ['key', 10, 2], ld: 'meow'})
+        assert.deepEqual ['key', 10-1, 3], type.transformCursor(['key', 10, 3], {p: ['key', 9], ld: 'meow'})
+      it 'handles deletes after', ->
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 4], ld: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 11], ld: 'meow'})
+      it 'handles deletes at current point', ->
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], ld: 'meow'})
+        assert.deepEqual ['key', 10], type.transformCursor(['key', 10, 3], {p: ['key', 10], ld: 'meow'})
+      it 'handles movements of current point', ->
+        assert.deepEqual ['key', 10, 20], type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], lm: 20})
+        assert.deepEqual ['key', 20, 3], type.transformCursor(['key', 10, 3], {p: ['key', 10], lm: 20})
+      it 'ignores irrelevant operations', ->
+        assert.deepEqual ['key', 10, 20], type.transformCursor(['key', 10, 3], {p: ['key', 10, 2], lm: 20})
+        assert.deepEqual ['key', 20, 3], type.transformCursor(['key', 10, 3], {p: ['key', 9], lm: 20})
+    describe 'dict operations', ->
+      it 'ignores irrelevant inserts and deletes', ->
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key2'], oi: 'meow'})
+        assert.deepEqual ['key', 10, 3], type.transformCursor(['key', 10, 3], {p: ['key2'], od: 'meow'})
+      it 'handles deletes at current point', ->
+        assert.deepEqual [], type.transformCursor(['key', 0, 3], {p: ['key'], od: ['meow123']})
+        assert.deepEqual ['key', 10], type.transformCursor(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123']})
+      it 'handles replacements at current point', ->
+        assert.deepEqual ['key'], type.transformCursor(['key', 0, 3], {p: ['key'], od: ['meow123'], oi: 'newobj'})
+        assert.deepEqual ['key', 10, 'key2'], type.transformCursor(['key', 0, 'key2'], {p: ['key', 0, 'key2'], od: ['meow123'], oi: 'newobj'})
+    describe 'subtype operations', ->
+      it 'warns that they are unsupported', ->
+        assert.throws(->
+          type.transformCursor(['key', 10, 3], {p: ['key', 10, 3], t: 'text0', o: 'testop'})
+        , /subtype.*unsupported/)
+
   describe 'randomizer', ->
     @timeout 20000
     @slow 6000


### PR DESCRIPTION
Still could use some cleanup, but since there's been no commits since 2015, thought I'd post this first to gauge interest/probability of of a merge. It also doesn't support subtype ops (although `sd` and `si` are supported), if this is wanted I'd implement it by forwarding the cursor transform on to the subtype.

This implements `transformCursor`. Cursor positions have the same format as a op path, so for instance if the cursor was halfway through 'meow' in `{'key': [0,1,"meow"]}`, the cursor would be `['key', 2, 2]`.