### PR TITLE
⬆️ Run build against modern Node.js versions

### DIFF
--- a/.mocharc.yml
+++ b/.mocharc.yml
@@ -1,0 +1,2 @@
+reporter: spec
+check-leaks: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,8 @@ language: node_js
 
 node_js:
   - 8
+  - 10
+  - 12
+  - 14
+  - 16
 

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "ot-fuzzer": "^1.0.0",
-    "mocha": "^1.20.1",
-    "coffee-script": "^1.7.1"
+    "coffee-script": "^1.7.1",
+    "mocha": "^9.0.2",
+    "ot-fuzzer": "^1.0.0"
   },
   "scripts": {
-    "test": "mocha"
+    "test": "mocha --require 'coffee-script/register' 'test/**'"
   },
   "repository": {
     "type": "git",

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,0 @@
---compilers coffee:coffee-script/register
---reporter spec
---check-leaks


### PR DESCRIPTION
Node.js 8 has been [end-of-lifed][1]. This change bumps our version of
`mocha` so that we can run the build against newer versions of Node.js.

The change of `mocha` syntax is because the `compilers` option was
[deprecated][2].

[1]: https://nodejs.org/en/about/releases/
[2]: https://github.com/mochajs/mocha/wiki/compilers-deprecation