### PR TITLE
🙈 Ignore `package-lock.json`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.swp
 *.DS_Store
 node_modules
+package-lock.json


### PR DESCRIPTION
`package-lock.json` is [never published][1], and therefore irrelevant to
libraries (as opposed to "apps").

This change adds the lockfile to `.gitignore` so we don't commit it,
reducing commit noise.

[1]: https://docs.npmjs.com/cli/v7/configuring-npm/package-lock-json#package-lockjson-vs-npm-shrinkwrapjson