### PR TITLE
🔧 Only include `lib/` when publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "directories": {
     "test": "test"
   },
+  "files": [
+    "lib"
+  ],
   "dependencies": {},
   "devDependencies": {
     "coffee-script": "^1.7.1",


### PR DESCRIPTION
At the moment, we publish all the files in the library, including test
files.

This change only includes the `lib/` folder using the `package.json`
[`files`][1] setting.

Here are the results of `npm publish --dry-run`:

## Before

```
=== Tarball Contents ===
4.4kB  test/json0-generator.coffee
25.7kB test/json0.coffee
906B   test/text0-generator.coffee
6.0kB  test/text0.coffee
2.7kB  lib/bootstrapTransform.js
252B   lib/index.js
17.9kB lib/json0.js
7.9kB  lib/text0.js
727B   package.json
11.7kB README.md
33B    .mocharc.yml
63B    .travis.yml
=== Tarball Details ===
name:          ot-json0
version:       1.1.0
package size:  19.4 kB
unpacked size: 78.2 kB
shasum:        3ef41b3402b6255d727992810b4ea6fbacfbd798
integrity:     sha512-hp81nqHTqoAia[...]bi7qE2ranGRRw==
total files:   12
```

## After

```
=== Tarball Contents ===
2.7kB  lib/bootstrapTransform.js
252B   lib/index.js
17.9kB lib/json0.js
7.9kB  lib/text0.js
755B   package.json
11.7kB README.md
=== Tarball Details ===
name:          ot-json0
version:       1.1.0
package size:  12.6 kB
unpacked size: 41.1 kB
shasum:        81cc563345890bb9d57f27cf5bf07f699f7a908c
integrity:     sha512-v+J/at+tFLd/U[...]xqQynJWArc0ig==
total files:   6
```

[1]: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#files