### PR TITLE
🥅 Throw a more useful message when subtypes are not invertible

### DIFF
--- a/lib/json0.js
+++ b/lib/json0.js
@@ -70,6 +70,9 @@ json.invertComponent = function(c) {
 
   // handle subtype ops
   if (c.t && subtypes[c.t]) {
+    if (typeof subtypes[c.t].invert !== 'function') {
+      throw new Error("Subtype '" + c.t + "' is not invertible");
+    }
     c_.t = c.t;
     c_.o = subtypes[c.t].invert(c.o);
   }


### PR DESCRIPTION
The `invert()` method assumes that all subtypes are invertible. However,
the OT type `invert()` method is [optional][1], so not all types will
have it implemented (`rich-text` is a notable example).

This change checks for presence of the `invert()` function, and throws
a more descriptive error if it's not present.

[1]: https://github.com/ottypes/docs#optional-properties